### PR TITLE
Feature/close streams

### DIFF
--- a/pkg/oracle_node.go
+++ b/pkg/oracle_node.go
@@ -84,11 +84,6 @@ func NewOracleNode(ctx context.Context, privKey crypto.PrivKey, portNbr int, use
 		return nil, err
 	}
 
-	dht, err := dht.New(ctx, host)
-	if err != nil {
-		return nil, err
-	}
-
 	return &OracleNode{
 		Host:       host,
 		PrivKey:    privKey,
@@ -96,7 +91,6 @@ func NewOracleNode(ctx context.Context, privKey crypto.PrivKey, portNbr int, use
 		multiAddrs: myNetwork.GetMultiAddressForHostQuiet(host),
 		Context:    ctx,
 		PeerChan:   make(chan myNetwork.PeerEvent),
-		DHT:        dht,
 	}, nil
 }
 


### PR DESCRIPTION
# Close Streams After Use

## Description
This PR addresses a potential resource leak in our codebase. We are now explicitly closing streams after we're done using them in the `readData` and `writeData` methods.

## Changes

1. **Update the `readData` and `writeData` methods in `oracle_node.go`**:
   - Accept an additional `stream` argument.
   - Close the stream after use.
   - Implemented as follows:

     ```go
     func (node *OracleNode) readData(rw *bufio.ReadWriter, event myNetwork.PeerEvent, stream network.Stream) {
        defer func() {
            err := stream.Close()
            if err != nil {
                logrus.Error("Error closing stream:", err)
            }
        }()
        // ... 
     }

     func (node *OracleNode) writeData(rw *bufio.ReadWriter, event myNetwork.PeerEvent, stream network.Stream) {
        defer func() {
            err := stream.Close()
            if err != nil {
                logrus.Error("Error closing stream:", err)
            }
        }()
        // ... 
     }
     ```

2. **Update all calls to `readData` and `writeData`**:
   - Include the `stream` argument.
   - Example usage:

     ```go
     go node.readData(rw, myNetwork.PeerEvent{Source: "StreamHandler"}, stream)
     go node.writeData(rw, myNetwork.PeerEvent{Source: "StreamHandler"}, stream)
     ```