### PR TITLE
Add endpoint to retrieve all node data

### DIFF
--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"github.com/gin-gonic/gin"
+
 	masa "github.com/masa-finance/masa-oracle/pkg"
 	"github.com/masa-finance/masa-oracle/pkg/api"
 )


### PR DESCRIPTION
## Description
This pull request introduces a new endpoint to the Masa Oracle Node API that allows clients to retrieve all collected node data. The new endpoint responds to GET requests at the path /nodeData and returns a JSON array of node data objects.
## Changes
- Added a new route in routes.go to handle GET requests for /nodeData.
- Implemented GetNodeDataHandler in api.go which utilizes the NodeTracker's GetAllNodeData method to fetch and return all node data.
- Ensured that NodeTracker is properly initialized in the OracleNode instance.
## How to Test
To test the new endpoint, run the following curl command:
`curl -X GET http://localhost:8080/nodeData`
Make sure to replace `http://localhost:8080` with the actual server address and port.
## Impact
This addition provides API consumers with the ability to monitor and retrieve comprehensive data about the nodes in the network, which can be useful for analytics, monitoring, and debugging purposes.