### PR TITLE
02 07 testnet bug fixes

### DIFF
--- a/cmd/masa-node/cli.go
+++ b/cmd/masa-node/cli.go
@@ -53,7 +53,11 @@ func init() {
 		if !tcp {
 			tcp = getEnvAsBool("TCP", false)
 		}
-
+		// if neither UDP nor TCP are set, default to UDP
+		if !udp && !tcp {
+			udp = true
+			tcp = false
+		}
 		if flagBootnodes != "" {
 			bootnodes = flagBootnodes
 		} else {

--- a/cmd/masa-node/main.go
+++ b/cmd/masa-node/main.go
@@ -154,6 +154,7 @@ func setUpFiles(envFilePath, keyFilePath string) error {
 		// If not, create it with default values
 		builder := strings.Builder{}
 		builder.WriteString(fmt.Sprintf("%s=%s\n", masa.KeyFileKey, keyFilePath))
+		builder.WriteString(fmt.Sprintf("RPC_URL=%s\n", masa.DefaultRPCURL))
 		err = os.WriteFile(envFilePath, []byte(builder.String()), 0644)
 		if err != nil {
 			logrus.Error("could not write to .env file:")

--- a/pkg/constants.go
+++ b/pkg/constants.go
@@ -22,6 +22,7 @@ const (
 	NodeBackupFileName   = "nodeBackup.json"
 	NodeBackupPath       = "nodeBackupPath"
 	Version              = "v0.0.4-alpha"
+	DefaultRPCURL        = "https://ethereum-sepolia.publicnode.com"
 )
 
 func ProtocolWithVersion(protocolName string) protocol.ID {

--- a/pkg/pubsub/node_event_tracker.go
+++ b/pkg/pubsub/node_event_tracker.go
@@ -80,17 +80,14 @@ func (net *NodeEventTracker) Connected(n network.Network, c network.Conn) {
 func (net *NodeEventTracker) Disconnected(n network.Network, c network.Conn) {
 	logrus.Debug("Disconnect")
 
-	pubKeyHex := getEthAddress(c.RemotePeer(), n)
 	peerID := c.RemotePeer().String()
 
 	nodeData, exists := net.nodeData.Get(peerID)
-	if !nodeData.IsStaked {
-		return
-	}
 	if !exists {
 		// this should never happen
 		logrus.Warnf("Node data does not exist for disconnected node: %s", peerID)
-		nodeData = NewNodeData(c.RemoteMultiaddr(), c.RemotePeer(), pubKeyHex, ActivityLeft)
+	} else if !nodeData.IsStaked {
+		return
 	}
 	logrus.WithFields(logrus.Fields{
 		"Peer":    c.RemotePeer().String(),


### PR DESCRIPTION
main issue is the null pointer on nodeData that doesn't exist for Disconnecting node.
added default RPC_URL to the .env file.