### PR TITLE
Fix timing issues for nodes

### DIFF
--- a/cmd/masa-node/cli.go
+++ b/cmd/masa-node/cli.go
@@ -4,7 +4,10 @@ package main
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"os"
+	"os/user"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -69,11 +72,23 @@ func init() {
 			}
 			bootnodes = strings.Join(config.Bootnodes, ",")
 		}
-		err := os.Setenv(masa.Environment, env)
-		if err != nil {
-			logrus.Error(err)
+		if env != "" {
+			err := os.Setenv(masa.Environment, env)
+			if err != nil {
+				logrus.Error(err)
+			}
+			usr, err := user.Current()
+			if err != nil {
+				logrus.Error("could not find user.home directory")
+			}
+			backupFileName := fmt.Sprintf("%s_%s_%s", masa.Version, env, masa.NodeBackupFileName)
+			err = os.Setenv(masa.NodeBackupPath, filepath.Join(usr.HomeDir, ".masa", backupFileName))
+			if err != nil {
+				logrus.Error(err)
+			}
+
 		}
-		err = os.Setenv(masa.Peers, bootnodes)
+		err := os.Setenv(masa.Peers, bootnodes)
 		if err != nil {
 			logrus.Error(err)
 		}

--- a/pkg/oracle_node.go
+++ b/pkg/oracle_node.go
@@ -111,7 +111,7 @@ func NewOracleNode(ctx context.Context, privKey crypto.PrivKey, portNbr int, use
 		multiAddrs:    myNetwork.GetMultiAddressesForHostQuiet(hst),
 		Context:       ctx,
 		PeerChan:      make(chan myNetwork.PeerEvent),
-		NodeTracker:   pubsub2.NewNodeEventTracker(Version),
+		NodeTracker:   pubsub2.NewNodeEventTracker(Version, getEnv()),
 		PubSubManager: subscriptionManager,
 		IsStaked:      isStaked,
 	}, nil
@@ -127,7 +127,7 @@ func (node *OracleNode) Start() (err error) {
 
 	node.Host.SetStreamHandler(node.Protocol, node.handleStream)
 	node.Host.SetStreamHandler(ProtocolWithVersion(NodeDataSyncProtocol), node.ReceiveNodeData)
-	//if node.IsStaked then allow them to be added to the NodeData -- move to node tracker
+	// if node.IsStaked then allow them to be added to the NodeData -- move to node tracker
 	if node.IsStaked {
 		node.Host.SetStreamHandler(ProtocolWithVersion(NodeGossipTopic), node.GossipNodeData)
 	}
@@ -180,7 +180,7 @@ func (node *OracleNode) handleDiscoveredPeers() {
 			if peer.Action == myNetwork.PeerAdded {
 				if err := node.Host.Connect(node.Context, peer.AddrInfo); err != nil {
 					logrus.Errorf("Connection failed for peer: %s %v", peer.AddrInfo.ID.String(), err)
-					//close the connection
+					// close the connection
 					err := node.Host.Network().ClosePeer(peer.AddrInfo.ID)
 					if err != nil {
 						logrus.Error(err)
@@ -198,7 +198,7 @@ func (node *OracleNode) handleStream(stream network.Stream) {
 	remotePeer, nodeData, err := node.handleStreamData(stream)
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "un-staked") {
-			//just ignore the error
+			// just ignore the error
 			return
 		}
 		logrus.Errorf("Failed to read stream: %v", err)

--- a/pkg/pubsub/node_data.go
+++ b/pkg/pubsub/node_data.go
@@ -77,14 +77,14 @@ func (n *NodeData) Address() string {
 }
 
 func (n *NodeData) Joined() {
-	if n.Activity == ActivityJoined && n.IsActive {
-		if n.IsStaked {
-			logrus.Warnf("Node %s is already marked as joined", n.Address())
-		} else {
-			logrus.Debugf("Node %s is already marked as joined", n.Address())
-		}
-		return
-	}
+	// if n.Activity == ActivityJoined && n.IsActive {
+	// 	if n.IsStaked {
+	// 		logrus.Warnf("Node %s is already marked as joined", n.Address())
+	// 	} else {
+	// 		logrus.Debugf("Node %s is already marked as joined", n.Address())
+	// 	}
+	// 	return
+	// }
 	now := time.Now()
 	n.LastJoined = now
 	n.LastUpdated = now


### PR DESCRIPTION
 - [x] Modified the Node Tracking Structure: Introduce a structure to buffer connect events for already connected nodes.
 - [x] Adjusted the Connected Method: When a connect event is received for an already connected node, buffer the event instead of processing it immediately.
 - [x]  Adjusted the Disconnected Method: Check if there's a buffered connect event for the disconnecting node and process the events in the correct order.
 - [x]  Periodically Clear Expired Buffer Entries: Implement a routine to periodically check and clear buffered connect events that have not been followed by a disconnect within the buffer period.
 - [x]  Update the backup file name to include the environment