### PR TITLE
just copy .env to the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ RUN chmod +x /usr/bin/masa-node
 USER masa
 WORKDIR /home/masa
 
+# Copy the .env file into the container
+COPY --chown=masa:masa .env .
+
 # Expose necessary ports
 EXPOSE 4001
 EXPOSE 8080

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,10 +5,6 @@ services:
     ports:
       - "4001:4001"
       - "8080:8080"
-    environment:
-      BOOTNODES: "${BOOTNODES}"
-      ENV: "${ENV}"
-      RPC_URL: "${RPC_URL}"
     volumes:
       - .:/app
       - .masa-keys:/home/masa/.masa


### PR DESCRIPTION
Just updates Docker to work in a more straightforward way with the operator's env file (just copy to container).