### PR TITLE
fix: remove ======= from md metadata because it causes docs to crash

### DIFF
--- a/docs/oracle-node/introduction.md
+++ b/docs/oracle-node/introduction.md
@@ -1,6 +1,5 @@
 ---
 id: introduction
-=======
 title: Introduction
 ---
 

--- a/docs/validator-node/introduction.md
+++ b/docs/validator-node/introduction.md
@@ -1,6 +1,5 @@
 ---
 id: introduction
-=======
 title: Introduction
 ---
 

--- a/docs/worker-node/introduction.md
+++ b/docs/worker-node/introduction.md
@@ -1,6 +1,5 @@
 ---
 id: introduction
-=======
 title: Introduction
 ---
 


### PR DESCRIPTION
docs repo cant build because of those equal signs: https://vercel.com/masa-finance/masa-docs/DB3wyuBXmKqEj1ZZjCLJPqSk1YyC?filter=errors