### PR TITLE
github: add release-notes configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,31 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: "Bug fixes :bug:"
+      labels:
+        - bug
+        - regression
+    - title: Exciting New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+        - ux
+        - roadmap
+    - title: 📖 Documentation and examples
+      labels:
+        - kind/documentation
+        - examples
+    - title: 👒 Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
related to https://github.com/masa-finance/masa-oracle/issues/393

Bittensor similar ticket: https://github.com/masa-finance/masa-bittensor/issues/83

Adds github configuration to generate release notes automatically from labels in the PR
