### PR TITLE
chore: remove core-team from dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,4 +16,4 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "masa-finance/core-team"
+      - "masa-finance/protocol"


### PR DESCRIPTION
Use Protocol team instead