### PR TITLE
ci: add commitlint workflow

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,13 @@
+name: Commitlint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    name: Commitlint
+    steps:
+      - name: Run commitlint
+        uses: opensource-nepal/commitlint@v1


### PR DESCRIPTION
This adds a pipeline running opensource-nepal/commitlint for checking commits are following conventional commits before merging a PR. 

https://www.conventionalcommits.org/en/v1.0.0/

In scope of #393 