### PR TITLE
fix: private ip address issue in node data

### DIFF
--- a/pkg/network/address.go
+++ b/pkg/network/address.go
@@ -56,10 +56,7 @@ func GetPriorityAddress(addrs []multiaddr.Multiaddr) multiaddr.Multiaddr {
 	for _, addr := range addrs {
 		ipComponent, err := addr.ValueForProtocol(multiaddr.P_IP4)
 		if err != nil {
-			ipComponent, err = addr.ValueForProtocol(multiaddr.P_IP6)
-			if err != nil {
-				continue // Not an IP address
-			}
+			continue // Not an IP address
 		}
 
 		ip := net.ParseIP(ipComponent)
@@ -114,7 +111,7 @@ func getBestPublicAddress(addrs []multiaddr.Multiaddr) multiaddr.Multiaddr {
 
 	// Find a suitable port from existing addresses
 	for _, addr := range addrs {
-		if strings.HasPrefix(addr.String(), "/ip4/") || strings.HasPrefix(addr.String(), "/ip6/") {
+		if strings.HasPrefix(addr.String(), "/ip4/") {
 			port, err := addr.ValueForProtocol(multiaddr.P_TCP)
 			if err == nil {
 				return publicAddr.Encapsulate(multiaddr.StringCast("/tcp/" + port))

--- a/pkg/network/address.go
+++ b/pkg/network/address.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// GetMultiAddressesForHost returns the multiaddresses for the host
 func GetMultiAddressesForHost(host host.Host) ([]multiaddr.Multiaddr, error) {
 	peerInfo := peer.AddrInfo{
 		ID:    host.ID(),
@@ -34,6 +35,7 @@ func GetMultiAddressesForHost(host host.Host) ([]multiaddr.Multiaddr, error) {
 	return addresses, nil
 }
 
+// GetMultiAddressesForHostQuiet returns the multiaddresses for the host without logging
 func GetMultiAddressesForHostQuiet(host host.Host) []multiaddr.Multiaddr {
 	ma, err := GetMultiAddressesForHost(host)
 	if err != nil {
@@ -42,6 +44,7 @@ func GetMultiAddressesForHostQuiet(host host.Host) []multiaddr.Multiaddr {
 	return ma
 }
 
+// GetPriorityAddress returns the best public or private IP address
 func GetPriorityAddress(addrs []multiaddr.Multiaddr) multiaddr.Multiaddr {
 	bestAddr := getBestPublicAddress(addrs)
 	if bestAddr != nil {
@@ -83,6 +86,7 @@ func GetPriorityAddress(addrs []multiaddr.Multiaddr) multiaddr.Multiaddr {
 	return nil
 }
 
+// getBestPublicAddress returns the best public IP address
 func getBestPublicAddress(addrs []multiaddr.Multiaddr) multiaddr.Multiaddr {
 	var externalIP net.IP
 	var err error
@@ -121,6 +125,7 @@ func getBestPublicAddress(addrs []multiaddr.Multiaddr) multiaddr.Multiaddr {
 	return publicAddr
 }
 
+// isPreferredAddress checks if the multiaddress contains the UDP protocol
 func isPreferredAddress(addr multiaddr.Multiaddr) bool {
 	// Check if the multiaddress contains the UDP protocol
 	for _, p := range addr.Protocols() {
@@ -131,6 +136,7 @@ func isPreferredAddress(addr multiaddr.Multiaddr) bool {
 	return false
 }
 
+// getOutboundIP returns the outbound IP address of the current machine 172.17.0.2 10.0.0.2 etc
 func getOutboundIP() string {
 	conn, err := net.Dial("udp", "8.8.8.8:80")
 	if err != nil {
@@ -142,6 +148,7 @@ func getOutboundIP() string {
 	return localAddr[0:idx]
 }
 
+// GetBootNodesMultiAddress returns the multiaddresses for the bootstrap nodes
 func GetBootNodesMultiAddress(bootstrapNodes []string) ([]multiaddr.Multiaddr, error) {
 	addrs := make([]multiaddr.Multiaddr, 0)
 	for _, peerAddr := range bootstrapNodes {

--- a/pkg/oracle_node.go
+++ b/pkg/oracle_node.go
@@ -456,7 +456,7 @@ func SubscribeToBlocks(ctx context.Context, node *OracleNode) {
 
 	go node.Blockchain.Init()
 
-	updateTicker := time.NewTicker(time.Minute)
+	updateTicker := time.NewTicker(time.Second * 60)
 	defer updateTicker.Stop()
 
 	for {
@@ -472,7 +472,7 @@ func SubscribeToBlocks(ctx context.Context, node *OracleNode) {
 			}
 
 		case <-updateTicker.C:
-			logrus.Info("[+] blockchain ticker")
+			logrus.Info("[+] blockchain tick")
 			if err := updateBlocks(ctx, node); err != nil {
 				logrus.Errorf("[-] Error updating blocks: %v", err)
 				// Consider adding a retry mechanism or circuit breaker here

--- a/pkg/oracle_node.go
+++ b/pkg/oracle_node.go
@@ -438,12 +438,12 @@ func updateBlocks(ctx context.Context, node *OracleNode) error {
 
 		hash, err := sh.AddWithOpts(reader, true, true)
 		if err != nil {
-			logrus.Errorf("[-]Error persisting to IPFS: %s", err)
-			os.Exit(1)
-		}
+			logrus.Errorf("[-] Error persisting to IPFS: %s", err)
+		} else {
+			logrus.Printf("[+] Ledger persisted with IPFS hash: https://dwn.infura-ipfs.io/ipfs/%s\n", hash)
+			_ = node.DHT.PutValue(ctx, "/db/ipfs", []byte(fmt.Sprintf("https://dwn.infura-ipfs.io/ipfs/%s", hash)))
 
-		logrus.Printf("[+] Ledger persisted with IPFS hash: https://dwn.infura-ipfs.io/ipfs/%s\n", hash)
-		_ = node.DHT.PutValue(ctx, "/db/ipfs", []byte(fmt.Sprintf("https://dwn.infura-ipfs.io/ipfs/%s", hash)))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**Description**

This PR fixes #439 

Currently the private ip address of a node can find its way into the node data. The node data is used to filter through validators and workers and this requires the public ip to always be stored in the node data for processing.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to Masa! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR. 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

-->
