### PR TITLE
fix: Nil Pointer Dereference Errors in DHT Initialization and Usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ docs/api-reference.md
 ./masa-node
 transcription.txt
 snippets.txt
+.env copy

--- a/pkg/db/resolver_cache.go
+++ b/pkg/db/resolver_cache.go
@@ -192,7 +192,14 @@ func iterateAndPublish(ctx context.Context, node *masa.OracleNode) {
 	records, err := QueryAll(ctx)
 	if err != nil {
 		logrus.Errorf("[-] Error querying all records: %+v", err)
+		return
 	}
+
+	if node.DHT == nil {
+		logrus.Errorf("DHT instance is nil. Skipping iterateAndPublish operation.")
+		return
+	}
+
 	for _, record := range records {
 		key := record.Key
 		if len(key) > 0 && key[0] == '/' {
@@ -215,7 +222,7 @@ func iterateAndPublish(ctx context.Context, node *masa.OracleNode) {
 		// sync ipfs
 		ipfs, e := node.DHT.GetValue(ctx, "/db/ipfs")
 		if e != nil {
-			logrus.Debugf("[-] Error unmarshalling IPFS data: %v", err)
+			logrus.Debugf("[-] Error unmarshalling IPFS data: %v", e)
 		} else {
 			_ = WriteData(node, "ipfs", ipfs)
 		}

--- a/pkg/oracle_node_listener.go
+++ b/pkg/oracle_node_listener.go
@@ -172,9 +172,13 @@ func (node *OracleNode) ReceiveNodeData(stream network.Stream) {
 				for _, p := range page.Data {
 					jsonData, _ := json.Marshal(p)
 					_ = json.Unmarshal(jsonData, &nd)
-					err := node.DHT.PutValue(context.Background(), "/db/"+nd.PeerId.String(), jsonData)
-					if err != nil {
-						logrus.Errorf("[-] %v", err)
+					if node.DHT != nil { // Check if DHT is not nil
+						err := node.DHT.PutValue(context.Background(), "/db/"+nd.PeerId.String(), jsonData)
+						if err != nil {
+							logrus.Errorf("[-] %v", err)
+						}
+					} else {
+						logrus.Errorf("DHT instance is nil. Skipping PutValue operation.")
 					}
 				}
 			}


### PR DESCRIPTION
## Fix Nil Pointer Dereference Errors in DHT Initialization and Usage

### Description:
This PR addresses potential nil pointer dereference errors in the handling of the DHT (Distributed Hash Table) object within our network package. By ensuring that the `kademliaDHT` object is properly checked for `nil` before usage, we prevent runtime panics that could occur due to nil pointer dereferences. This enhances the robustness and reliability of our DHT operations, particularly during the bootstrap process and when interacting with the DHT for data retrieval and publishing.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x991 pc=0x1053e7900]

goroutine 2425 [running]:
github.com/libp2p/go-libp2p-kad-dht.(*IpfsDHT).PutValue(0x0, {0x106182ea0, 0x107777240}, {0x14001944340, 0x39}, {0x14002628200, 0x1f6, 0x200}, {0x0, 0x0, ...})
        /Users/brendanplayford/go/pkg/mod/github.com/libp2p/go-libp2p-kad-dht@v0.25.2/routing.go:39 +0x160
github.com/masa-finance/masa-oracle/pkg.(*OracleNode).ReceiveNodeData(0x14001995b20, {0x106198870, 0x14002637d80})
        /Users/brendanplayford/masa-oracle/pkg/oracle_node_listener.go:175 +0x408
github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).SetStreamHandler.func1({0x106d5dfc0?, 0x1060e9840?}, {0x12ec8c000?, 0x14002637d80?})
        /Users/brendanplayford/go/pkg/mod/github.com/libp2p/go-libp2p@v0.34.0/p2p/host/basic/basic_host.go:610 +0x8c
github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).newStreamHandler(0x140001e8780, {0x106198870, 0x14002637d80})
        /Users/brendanplayford/go/pkg/mod/github.com/libp2p/go-libp2p@v0.34.0/p2p/host/basic/basic_host.go:449 +0x618
github.com/libp2p/go-libp2p/p2p/net/swarm.(*Conn).start.func1.1()
        /Users/brendanplayford/go/pkg/mod/github.com/libp2p/go-libp2p@v0.34.0/p2p/net/swarm/swarm_conn.go:142 +0xac
created by github.com/libp2p/go-libp2p/p2p/net/swarm.(*Conn).start.func1 in goroutine 1067
        /Users/brendanplayford/go/pkg/mod/github.com/libp2p/go-libp2p@v0.34.0/p2p/net/swarm/swarm_conn.go:128 +0x1a0
make: *** [run] Error 2
(base) brendanplayford@Brendans-MacBook-Pro masa-oracle % 
```

#### Changes:
1. **`kdht.go`**: Added comprehensive nil checks around the usage of `kademliaDHT` to ensure that operations are only attempted if the object is properly initialized. This includes checks before bootstrapping the DHT and before adding or removing peers from the DHT's routing table.

2. **`resolver_cache.go`**: Implemented a nil check for `node.DHT` before attempting to retrieve or publish data to the DHT. This ensures that we avoid nil pointer dereferences when the DHT instance might not be initialized due to earlier errors or misconfigurations.

3. **Error Handling Enhancements**: Improved error handling and logging across DHT operations to provide clearer insights into failures and operational issues.

#### Justification:
The motivation behind these changes is to address and mitigate runtime errors encountered in our network layer, specifically related to the handling of the DHT object. By safeguarding against nil pointer dereferences, we aim to improve the stability and fault tolerance of our network operations, ensuring that our application can handle errors gracefully and maintain operational integrity under various conditions.

### Notes for Reviewers:
Please pay special attention to the added nil checks and error handling paths. Verify that the changes align with our error handling strategy and coding standards. Additionally, consider the potential impact of these changes on existing functionalities and performance. @jdutchak please review this thoroughly 