### PR TITLE
fix workflow to build binary with VERSION from git

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,9 +33,14 @@ jobs:
       with:
         go-version: '1.21'
     
+    - name: Set Version
+      run: echo "VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+
     - name: Build Binary
-      run: go build -v -o masa-node ./cmd/masa-node
-    
+      run: |
+        echo "Building with version: ${{ env.VERSION }}"
+        go build -v -ldflags "-X github.com/masa-finance/masa-oracle/pkg/config.Version=${{ env.VERSION }}" -o masa-node ./cmd/masa-node
+
     - id: auth
       uses: google-github-actions/auth@v2
       with:


### PR DESCRIPTION
**Description**

This PR fixes the binary built by the github action for use by the gcp based protocol nodes so that it includes the VERSION from git tags

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

