### PR TITLE
feat(workers): enhance error handling and worker selection in DistributeWork

### DIFF
--- a/pkg/workers/worker_manager.go
+++ b/pkg/workers/worker_manager.go
@@ -118,9 +118,15 @@ func (whm *WorkHandlerManager) DistributeWork(node *masa.OracleNode, workRequest
 			errors = append(errors, errorMsg)
 			logrus.Errorf("error sending work to worker: %s", errorMsg)
 			logrus.Infof("Remote worker %s failed, moving to next worker", worker.NodeData.PeerId)
-			continue
+
+			// Check if the error is related to Twitter authentication
+			if strings.Contains(response.Error, "unable to get twitter profile: there was an error authenticating with your Twitter credentials") {
+				logrus.Warnf("Worker %s failed due to Twitter authentication error. Skipping to the next worker.", worker.NodeData.PeerId)
+				continue // Skip to the next worker
+			}
+		} else {
+			return response
 		}
-		return response // Return immediately if a worker succeeds
 	}
 
 	// Fallback to local execution if local worker is eligible

--- a/pkg/workers/worker_manager.go
+++ b/pkg/workers/worker_manager.go
@@ -122,14 +122,14 @@ func (whm *WorkHandlerManager) DistributeWork(node *masa.OracleNode, workRequest
 			// Check if the error is related to Twitter authentication
 			if strings.Contains(response.Error, "unable to get twitter profile: there was an error authenticating with your Twitter credentials") {
 				logrus.Warnf("Worker %s failed due to Twitter authentication error. Skipping to the next worker.", worker.NodeData.PeerId)
-				continue // Skip to the next worker
+				continue
 			}
 		} else {
 			return response
 		}
 	}
 
-	// Fallback to local execution if local worker is eligible
+	// Fallback to local execution if local worker is eligible and all remote workers failed
 	if localWorker != nil {
 		response = whm.ExecuteWork(workRequest)
 		if response.Error != "" {

--- a/pkg/workers/worker_selection.go
+++ b/pkg/workers/worker_selection.go
@@ -1,9 +1,7 @@
 package workers
 
 import (
-	"context"
 	"math/rand/v2"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -23,45 +21,15 @@ func GetEligibleWorkers(node *masa.OracleNode, category pubsub.WorkerCategory, c
 		nodes[i], nodes[j] = nodes[j], nodes[i]
 	})
 
-	logrus.Info("Checking connections to eligible workers")
-	start := time.Now()
+	logrus.Info("Getting eligible workers")
 	for _, eligible := range nodes {
 		if eligible.PeerId.String() == node.Host.ID().String() {
 			localWorker = &data_types.Worker{IsLocal: true, NodeData: eligible}
 			continue
 		}
-
-		// Use the DHT to find the peer's address information
-		peerInfo, err := node.DHT.FindPeer(context.Background(), eligible.PeerId)
-		if err != nil {
-			logrus.Warnf("Failed to find peer %s in DHT: %v", eligible.PeerId.String(), err)
-			continue
-		}
-
-		ctxWithTimeout, cancel := context.WithTimeout(context.Background(), config.ConnectionTimeout)
-		err = node.Host.Connect(ctxWithTimeout, peerInfo)
-		cancel()
-		if err != nil {
-			logrus.Warnf("Failed to connect to peer %s: %v", eligible.PeerId.String(), err)
-			continue
-		}
-
-		workers = append(workers, data_types.Worker{IsLocal: false, NodeData: eligible, AddrInfo: &peerInfo})
-		dur := time.Since(start).Milliseconds()
-		logrus.Infof("Worker selection took %v milliseconds", dur)
-		break
+		workers = append(workers, data_types.Worker{IsLocal: false, NodeData: eligible})
 	}
 
-	if localWorker == nil {
-		nd := node.NodeTracker.GetNodeData(node.Host.ID().String())
-		if nd != nil && nd.CanDoWork(category) {
-			localWorker = &data_types.Worker{IsLocal: true, NodeData: *nd}
-		}
-	}
-
-	if len(workers) == 0 && localWorker == nil {
-		logrus.Warn("No eligible workers found, including local worker")
-	}
-
+	logrus.Infof("Found %d eligible remote workers", len(workers))
 	return workers, localWorker
 }

--- a/twitter_cookies.example.json
+++ b/twitter_cookies.example.json
@@ -1,0 +1,88 @@
+  // How to obtain this information from your browser:
+  // 1. Log in to Twitter in your web browser
+  // 2. Open the browser's developer tools (usually F12 or right-click > Inspect)
+  // 3. Go to the "Application" or "Storage" tab
+  // 4. In the left sidebar, expand "Cookies" and click on "https://twitter.com"
+  // 5. Look for the cookie names listed above and copy their values
+  // 6. Replace the "X" placeholders in the "Value" field with the actual values
+  // 7. Save the file as "twitter_cookies.json" (remove ".example" from the filename)
+  
+  // Note: Most browsers only show the Name, Value, Domain, and Path fields in the developer tools.
+  // The other fields (Expires, MaxAge, Secure, HttpOnly, SameSite) may not be visible or editable.
+  // You can leave these fields as they are in this template.
+  
+  // IMPORTANT: Be extremely cautious with your auth_token and other sensitive cookies. 
+  // Never share them publicly or commit them to version control.
+  
+[
+    {
+      "Name": "personalization_id",
+      "Value": "v1_XXXXXXXXXXXXXXXXXXXXXXXX==",
+      "Path": "",
+      "Domain": "twitter.com",
+      "Expires": "0001-01-01T00:00:00Z",
+      "RawExpires": "",
+      "MaxAge": 0,
+      "Secure": false,
+      "HttpOnly": false,
+      "SameSite": 0,
+      "Raw": "",
+      "Unparsed": null
+    },
+    {
+      "Name": "kdt",
+      "Value": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "Path": "",
+      "Domain": "twitter.com",
+      "Expires": "0001-01-01T00:00:00Z",
+      "RawExpires": "",
+      "MaxAge": 0,
+      "Secure": false,
+      "HttpOnly": false,
+      "SameSite": 0,
+      "Raw": "",
+      "Unparsed": null
+    },
+    {
+      "Name": "twid",
+      "Value": "u=XXXXXXXXX",
+      "Path": "",
+      "Domain": "twitter.com",
+      "Expires": "0001-01-01T00:00:00Z",
+      "RawExpires": "",
+      "MaxAge": 0,
+      "Secure": false,
+      "HttpOnly": false,
+      "SameSite": 0,
+      "Raw": "",
+      "Unparsed": null
+    },
+    {
+      "Name": "ct0",
+      "Value": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "Path": "",
+      "Domain": "twitter.com",
+      "Expires": "0001-01-01T00:00:00Z",
+      "RawExpires": "",
+      "MaxAge": 0,
+      "Secure": false,
+      "HttpOnly": false,
+      "SameSite": 0,
+      "Raw": "",
+      "Unparsed": null
+    },
+    {
+      "Name": "auth_token",
+      "Value": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "Path": "",
+      "Domain": "twitter.com",
+      "Expires": "0001-01-01T00:00:00Z",
+      "RawExpires": "",
+      "MaxAge": 0,
+      "Secure": false,
+      "HttpOnly": false,
+      "SameSite": 0,
+      "Raw": "",
+      "Unparsed": null
+    }
+  ]


### PR DESCRIPTION
## Enhanced Worker Selection Process

### Problem
Our system was inefficiently utilizing available workers, often failing after attempting only a single remote worker if they had incorrectly setup Twitter credentials for example. This led to failure of requests if a single worker had a client side error.

### Solution
We've improved the worker selection process to attempt connections with all eligible remote workers before falling back to local execution. currently 10 workers will be attempted.

### Limitations 
This has not been tested in a large network of workers where there are multiple faulty worker nodes that need to be attempted. This requires a more elegant approach as outlined here where reliability and other factors are considered: https://github.com/masa-finance/masa-oracle/issues/544

### Acceptance Criteria
- [x] `GetEligibleWorkers` returns all eligible workers, not just the first connectable one
- [x] `DistributeWork` attempts to connect to each eligible worker sequentially
- [x] System tries all available remote workers (up to `MaxRemoteWorkers`) before giving up
- [x] Twitter incorrect credentials handled
- [x] Twitter 429's handled
- [x] Improved error handling and logging for better debugging and visibility
- [x] Maintained or improved task completion success rate

### Testing
This change has been tested in a production environment with multiple nodes, simulating various network conditions and worker availability scenarios. We observed improved resilience to individual worker failures and more consistent task distribution across the network.

### Incorrect credentials 
```bash
time="2024-09-03T19:54:39Z" level=error msg="error sending work to worker: Worker 16Uiu2HAmUjJJBfc8ynwM55ZY3tcmyVKbSqdBH1h3BrXYrKWNQwST: there was an error authenticating with your Twitter credentials"
time="2024-09-03T19:54:39Z" level=info msg="Remote worker 16Uiu2HAmUjJJBfc8ynwM55ZY3tcmyVKbSqdBH1h3BrXYrKWNQwST failed, moving to next worker"
time="2024-09-03T19:54:39Z" level=info msg="Attempting remote worker 16Uiu2HAmSCQMh22Xmo1GMxXB73qRx3YaVqqL1UwTYn3iNvQLjPB5 (attempt 2/10)"
```

### 429

```bash
time="2024-09-03T19:55:01Z" level=info msg="Attempting remote worker 16Uiu2HAmSCQMh22Xmo1GMxXB73qRx3YaVqqL1UwTYn3iNvQLjPB5 (attempt 1/10)"
time="2024-09-03T19:55:16Z" level=error msg="error sending work to worker: Worker 16Uiu2HAmSCQMh22Xmo1GMxXB73qRx3YaVqqL1UwTYn3iNvQLjPB5: Twitter API rate limit exceeded (429 error)"
time="2024-09-03T19:55:16Z" level=info msg="Remote worker 16Uiu2HAmSCQMh22Xmo1GMxXB73qRx3YaVqqL1UwTYn3iNvQLjPB5 failed, moving to next worker"
time="2024-09-03T19:55:16Z" level=info msg="Attempting remote worker 16Uiu2HAkxKqZuGzsvbqE9mjDixBiCkdwoSeAU3pGtHK3whcaCT7d (attempt 2/10)"
```