### PR TITLE
chore(ci): export coverage to codecov

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,4 +24,9 @@ jobs:
       run: go mod tidy
 
     - name: Run tests
-      run: go test ./...
+      run: go test -coverprofile=coverage.txt -covermode=atomic ./...
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
**Description**

This PR generates coverage files from test runs and upload these to codecov