### PR TITLE
chore(ci): fixup goreleaser permissions

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -10,7 +10,9 @@ permissions:
   contents: read
 
 jobs:  
-  goreleaser: # Add this new job for GoReleaser
+  goreleaser:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
**Description**

This PR fixes the goreleaser failing during tags. 

```
    • took: 12m26s
  • generating changelog
  ⨯ release failed after 12m26s              error=POST https://api.github.com/repos/masa-finance/masa-oracle/releases/generate-notes: 403 Resource not accessible by integration []
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.3.2/x64/goreleaser' failed with exit code 1
```

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to Masa! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR. 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

-->
