### PR TITLE
fix(blockchain): be more strict on blockchain data

### DIFF
--- a/cmd/masa-node/config.go
+++ b/cmd/masa-node/config.go
@@ -68,7 +68,7 @@ func initOptions(cfg *config.AppConfig) ([]node.Option, *workers.WorkHandlerMana
 		// and other peers can do work we only need to check this here
 		// if this peer can or cannot scrape or write that is checked in other places
 		masaNodeOptions = append(masaNodeOptions,
-			node.WithService(blockChainEventTracker.Start),
+			node.WithService(blockChainEventTracker.Start(config.GetInstance().MasaDir)),
 		)
 	}
 

--- a/node/blockchain.go
+++ b/node/blockchain.go
@@ -197,6 +197,8 @@ func processBlock(node *OracleNode, block *pubsub.Message) error {
 		}
 	}
 
+	// XXX: We miss here the logic to check if the block is actually valid
+	// and built AFTER our current block (!)
 	if err := node.Blockchain.AddBlock(block.Data); err != nil {
 		return fmt.Errorf("[-] failed to add block: %w", err)
 	}

--- a/node/blockchain.go
+++ b/node/blockchain.go
@@ -31,11 +31,10 @@ type Blocks struct {
 	BlockData []BlockData `json:"blocks"`
 }
 
-type BlockEvents struct{}
+type BlockEvents map[string]interface{}
 
 type BlockEventTracker struct {
 	BlockEvents []BlockEvents
-	BlockTopic  *pubsub.Topic
 	mu          sync.Mutex
 	blocksCh    chan *pubsub.Message
 }
@@ -75,7 +74,7 @@ func (b *BlockEventTracker) HandleMessage(m *pubsub.Message) {
 		b.BlockEvents = append(b.BlockEvents, v)
 	case map[string]interface{}:
 		// Convert map to BlockEvents struct
-		newBlockEvent := BlockEvents{}
+		newBlockEvent := BlockEvents(v)
 		// You might need to add logic here to properly convert the map to BlockEvents
 		b.BlockEvents = append(b.BlockEvents, newBlockEvent)
 	case []interface{}:

--- a/node/options.go
+++ b/node/options.go
@@ -10,12 +10,11 @@ import (
 )
 
 type NodeOption struct {
-	DisableCLIParse bool
-	IsStaked        bool
-	UDP             bool
-	TCP             bool
-	IsValidator     bool
-	PortNbr         int
+	IsStaked    bool
+	UDP         bool
+	TCP         bool
+	IsValidator bool
+	PortNbr     int
 
 	IsTwitterScraper  bool
 	IsDiscordScraper  bool
@@ -40,10 +39,6 @@ type PubSubHandlers struct {
 }
 
 type Option func(*NodeOption)
-
-var DisableCLIParse = func(o *NodeOption) {
-	o.DisableCLIParse = true
-}
 
 var EnableStaked = func(o *NodeOption) {
 	o.IsStaked = true

--- a/node/oracle_node.go
+++ b/node/oracle_node.go
@@ -44,7 +44,6 @@ type OracleNode struct {
 	Signature     string
 	StartTime     time.Time
 	WorkerTracker *pubsub.WorkerEventTracker
-	BlockTracker  *BlockEventTracker
 	Blockchain    *chain.Chain
 	Options       NodeOption
 	Context       context.Context

--- a/pkg/chain/block.go
+++ b/pkg/chain/block.go
@@ -23,7 +23,7 @@ func (b *Block) Build(data []byte, link []byte, stake *big.Int, block uint64) {
 	b.Data = data
 	b.Link = link
 
-	pos := &ProofOfStake{Block: b, Target: getProofOfStakeTarget(stake), Stake: stake}
+	pos := &ProofOfStake{Block: b, Target: GetProofOfStakeTarget(stake), Stake: stake}
 	b.Nonce, b.Hash = pos.Run()
 }
 

--- a/pkg/chain/block_test.go
+++ b/pkg/chain/block_test.go
@@ -1,0 +1,86 @@
+package chain_test
+
+import (
+	"math/big"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/masa-finance/masa-oracle/pkg/chain"
+)
+
+var _ = Describe("Block", func() {
+	var (
+		block       *Block
+		stake       *big.Int
+		data        []byte
+		link        []byte
+		blockNumber uint64
+	)
+
+	BeforeEach(func() {
+		block = &Block{}
+		stake = big.NewInt(1)
+		data = []byte("sample block data")
+		link = []byte("previous block hash")
+		blockNumber = 0
+	})
+
+	Describe("Build", func() {
+		It("should build the block with correct data and hash", func() {
+			block.Build(data, link, stake, blockNumber)
+
+			Expect(block.Block).To(Equal(blockNumber))
+			Expect(block.Data).To(Equal(data))
+			Expect(block.Link).To(Equal(link))
+			Expect(block.Hash).NotTo(BeNil())
+			Expect(block.Nonce).NotTo(BeZero())
+		})
+	})
+
+	Describe("Serialize", func() {
+		It("should serialize the block without error", func() {
+			block.Build(data, link, stake, blockNumber)
+
+			serializedData, err := block.Serialize()
+			Expect(err).To(BeNil())
+			Expect(serializedData).NotTo(BeNil())
+
+			// Ensure serialized data can be deserialized correctly
+			newBlock := &Block{}
+			err = newBlock.Deserialize(serializedData)
+			Expect(err).To(BeNil())
+			Expect(newBlock.Block).To(Equal(block.Block))
+			Expect(newBlock.Data).To(Equal(block.Data))
+			Expect(newBlock.Link).To(Equal(block.Link))
+			Expect(newBlock.Hash).To(Equal(block.Hash))
+			Expect(newBlock.Nonce).To(Equal(block.Nonce))
+		})
+	})
+
+	Describe("Deserialize", func() {
+		It("should deserialize correctly from serialized data", func() {
+			block.Build(data, link, stake, blockNumber)
+			serializedData, err := block.Serialize()
+			Expect(err).To(BeNil())
+
+			// Create a new block and deserialize from serialized data
+			newBlock := &Block{}
+			err = newBlock.Deserialize(serializedData)
+			Expect(err).To(BeNil())
+
+			// Compare fields between original and deserialized block
+			Expect(newBlock.Block).To(Equal(block.Block))
+			Expect(newBlock.Data).To(Equal(block.Data))
+			Expect(newBlock.Link).To(Equal(block.Link))
+			Expect(newBlock.Hash).To(Equal(block.Hash))
+			Expect(newBlock.Nonce).To(Equal(block.Nonce))
+		})
+
+		It("should return an error when deserializing invalid data", func() {
+			invalidData := []byte("invalid serialized data")
+			err := block.Deserialize(invalidData)
+			Expect(err).NotTo(BeNil())
+		})
+	})
+})

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/masa-finance/masa-oracle/pkg/config"
 	"github.com/sirupsen/logrus"
 )
 
@@ -25,8 +24,8 @@ type Chain struct {
 //
 // Returns:
 //   - error: An error if any step in the initialization process fails, nil otherwise.
-func (c *Chain) Init() error {
-	dataDir := filepath.Join(config.GetInstance().MasaDir, "./blocks")
+func (c *Chain) Init(path string) error {
+	dataDir := filepath.Join(path, "./blocks")
 	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
 		err = os.MkdirAll(dataDir, 0755)
 		if err != nil {

--- a/pkg/chain/chain_suite_test.go
+++ b/pkg/chain/chain_suite_test.go
@@ -1,0 +1,13 @@
+package chain_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOracle(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Oracle Chain test suite")
+}

--- a/pkg/chain/pos.go
+++ b/pkg/chain/pos.go
@@ -3,7 +3,6 @@ package chain
 import (
 	"bytes"
 	"crypto/sha256"
-	"fmt"
 	"math/big"
 	"time"
 
@@ -47,13 +46,13 @@ func (pos *ProofOfStake) Run() (int64, []byte) {
 	currentTime := time.Now().Unix()
 
 	logrus.WithFields(logrus.Fields{"nonce": currentTime}).Info("[+] Running Proof of Stake...")
-	spinner := []string{"|", "/", "-", "\\"}
+	//spinner := []string{"|", "/", "-", "\\"}
 	i := 0
 	for {
 		data := pos.joinData(currentTime)
 		hash = sha256.Sum256(data)
 		hashInt.SetBytes(hash[:])
-		fmt.Printf("\r%s %x", spinner[i%len(spinner)], hash)
+		//	fmt.Printf("\r%s %x", spinner[i%len(spinner)], hash)
 		i++
 		if hashInt.Cmp(pos.Target) == -1 {
 			break
@@ -61,7 +60,7 @@ func (pos *ProofOfStake) Run() (int64, []byte) {
 			currentTime++
 		}
 	}
-	fmt.Println()
+	//fmt.Println()
 	return currentTime, hash[:]
 }
 

--- a/pkg/chain/pos.go
+++ b/pkg/chain/pos.go
@@ -19,7 +19,7 @@ type ProofOfStake struct {
 	Stake  *big.Int
 }
 
-func getProofOfStakeTarget(stake *big.Int) *big.Int {
+func GetProofOfStakeTarget(stake *big.Int) *big.Int {
 	logrus.WithFields(logrus.Fields{"stake": stake}).Info("[+] Staked amount")
 	target := big.NewInt(1)
 	target.Lsh(target, uint(256-Difficulty))
@@ -67,7 +67,7 @@ func (pos *ProofOfStake) Run() (int64, []byte) {
 
 func IsValidPoS(block *Block, stake *big.Int) bool {
 	var hashIntegerRep big.Int
-	pos := &ProofOfStake{Block: block, Target: getProofOfStakeTarget(stake), Stake: stake}
+	pos := &ProofOfStake{Block: block, Target: GetProofOfStakeTarget(stake), Stake: stake}
 	data := pos.joinData(block.Nonce)
 	hash := sha256.Sum256(data)
 	hashIntegerRep.SetBytes(hash[:])

--- a/pkg/chain/pos_test.go
+++ b/pkg/chain/pos_test.go
@@ -1,0 +1,53 @@
+package chain_test
+
+import (
+	"math/big"
+
+	. "github.com/masa-finance/masa-oracle/pkg/chain"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ProofOfStake", func() {
+	var (
+		block *Block
+		stake *big.Int
+		pos   *ProofOfStake
+	)
+
+	BeforeEach(func() {
+		block = &Block{
+			Link: []byte("previous hash"),
+			Data: []byte("block data"),
+		}
+		stake = big.NewInt(1000)
+		pos = &ProofOfStake{
+			Block:  block,
+			Stake:  stake,
+			Target: GetProofOfStakeTarget(stake),
+		}
+	})
+
+	Describe("Run", func() {
+		It("finds a valid nonce and hash", func() {
+			nonce, hash := pos.Run()
+			Expect(nonce).To(BeNumerically(">", 0))
+			Expect(hash).NotTo(BeNil())
+
+			var hashInt big.Int
+			hashInt.SetBytes(hash)
+			Expect(hashInt.Cmp(pos.Target)).To(Equal(-1))
+		})
+	})
+
+	Describe("IsValidPoS", func() {
+		It("validates the block's proof of stake", func() {
+			nonce, _ := pos.Run()
+			block.Nonce = nonce
+
+			isValid := IsValidPoS(block, stake)
+			Expect(isValid).To(BeTrue())
+		})
+	})
+})

--- a/pkg/pubsub/manager.go
+++ b/pkg/pubsub/manager.go
@@ -3,6 +3,7 @@ package pubsub
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -83,6 +84,9 @@ func (sm *Manager) AddSubscription(topicName string, handler types.SubscriptionH
 			msg, err := sub.Next(sm.ctx)
 			if err != nil {
 				logrus.Errorf("[-] Error reading from topic: %v", err)
+				if errors.Is(err, context.Canceled) {
+					return
+				}
 				continue
 			}
 			if !includeSelf {
@@ -218,6 +222,9 @@ func (sm *Manager) Subscribe(topicName string, handler types.SubscriptionHandler
 			msg, err := sub.Next(sm.ctx)
 			if err != nil {
 				logrus.Errorf("[-] Error reading from topic: %v", err)
+				if errors.Is(err, context.Canceled) {
+					return
+				}
 				continue
 			}
 			// Skip messages from the same node

--- a/pkg/tests/integration/blockchain_test.go
+++ b/pkg/tests/integration/blockchain_test.go
@@ -82,14 +82,14 @@ var _ = Describe("Blockchain tests", func() {
 			publishBytes, err := json.Marshal(publishedData)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Publish data with the first node to kick off the first event
-			err = n.PublishTopic(config.BlockTopic, publishBytes)
-			Expect(err).ToNot(HaveOccurred())
-
 			// Eventually we should have at least one event
 			Eventually(func() int {
+				// Publish data with the first node to kick off the first event
+				err = n.PublishTopic(config.BlockTopic, publishBytes)
+				Expect(err).ToNot(HaveOccurred())
+
 				return len(blockChainEventTracker2.BlockEvents)
-			}, "30s").ShouldNot(Equal(0))
+			}, "1m").ShouldNot(Equal(0))
 
 			// Check that the event has the data that we published
 			Expect(blockChainEventTracker2.BlockEvents[0]).To(Equal(BlockEvents(publishedData)))

--- a/pkg/tests/integration/blockchain_test.go
+++ b/pkg/tests/integration/blockchain_test.go
@@ -1,0 +1,99 @@
+// Blockchain integration test
+package masa_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	. "github.com/masa-finance/masa-oracle/node"
+	"github.com/masa-finance/masa-oracle/pkg/config"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Blockchain tests", func() {
+	Context("blockchain events", func() {
+		It("contains data published by nodes and propagates correctly", func() {
+			ctx := context.Background()
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			tempDir, err := os.MkdirTemp("", "blockchain")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tempDir)
+
+			blockChainEventTracker := NewBlockChain()
+
+			// We create two nodes in this test - one publishes data over the blockchain
+			// and the other one should be able to receive the data
+			n, err := NewOracleNode(
+				ctx,
+				EnableStaked,
+				EnableRandomIdentity,
+				WithPubSubHandler(config.BlockTopic, blockChainEventTracker, true),
+				WithService(blockChainEventTracker.Start(tempDir)),
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = n.Start()
+			Expect(err).ToNot(HaveOccurred())
+
+			addrs, err := n.GetP2PMultiAddrs()
+			Expect(err).ToNot(HaveOccurred())
+
+			var bootNodes []string
+			for _, addr := range addrs {
+				bootNodes = append(bootNodes, addr.String())
+			}
+
+			By(fmt.Sprintf("Generating second node with bootnodes %+v", bootNodes))
+
+			tempDir2, err := os.MkdirTemp("", "blockchain")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tempDir)
+
+			// We start the second node (receives the data)
+			// And we also set the first node as bootstrap node
+			blockChainEventTracker2 := NewBlockChain()
+			n2, err := NewOracleNode(ctx,
+				EnableStaked,
+				WithBootNodes(bootNodes...),
+				EnableRandomIdentity,
+				WithPubSubHandler(config.BlockTopic, blockChainEventTracker2, true),
+				WithService(blockChainEventTracker2.Start(tempDir2)),
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(n.Host.ID()).ToNot(Equal(n2.Host.ID()))
+
+			err = n2.Start()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Initially, there shouldn't be any events in the blockchain
+			Eventually(func() int {
+				return len(blockChainEventTracker2.BlockEvents)
+			}, "30s").Should(Equal(0))
+
+			publishedData := map[string]interface{}{
+				"foo": interface{}("bar"),
+			}
+
+			publishBytes, err := json.Marshal(publishedData)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Publish data with the first node to kick off the first event
+			err = n.PublishTopic(config.BlockTopic, publishBytes)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Eventually we should have at least one event
+			Eventually(func() int {
+				fmt.Println(blockChainEventTracker2.BlockEvents)
+				return len(blockChainEventTracker2.BlockEvents)
+			}, "30s").ShouldNot(Equal(0))
+
+			// Check that the event has the data that we published
+			Expect(blockChainEventTracker2.BlockEvents[0]).To(Equal(BlockEvents(publishedData)))
+		})
+	})
+})

--- a/pkg/tests/integration/blockchain_test.go
+++ b/pkg/tests/integration/blockchain_test.go
@@ -88,7 +88,6 @@ var _ = Describe("Blockchain tests", func() {
 
 			// Eventually we should have at least one event
 			Eventually(func() int {
-				fmt.Println(blockChainEventTracker2.BlockEvents)
 				return len(blockChainEventTracker2.BlockEvents)
 			}, "30s").ShouldNot(Equal(0))
 

--- a/pkg/tests/integration/tracker_test.go
+++ b/pkg/tests/integration/tracker_test.go
@@ -20,7 +20,6 @@ var _ = Describe("Oracle integration tests", func() {
 			n, err := NewOracleNode(
 				ctx,
 				EnableStaked,
-				DisableCLIParse,
 				EnableRandomIdentity,
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -39,7 +38,6 @@ var _ = Describe("Oracle integration tests", func() {
 			By(fmt.Sprintf("Generating second node with bootnodes %+v", bootNodes))
 			n2, err := NewOracleNode(ctx,
 				EnableStaked,
-				DisableCLIParse,
 				WithBootNodes(bootNodes...),
 				EnableRandomIdentity,
 			)
@@ -70,7 +68,6 @@ var _ = Describe("Oracle integration tests", func() {
 
 			Expect(peerIds).To(ContainElement(n.Host.ID().String()))
 			Expect(peerIds).To(ContainElement(n2.Host.ID().String()))
-
 		})
 	})
 })


### PR DESCRIPTION
**Description**

Previously the blockchain data was treated as an empty struct - `struct {}`. That basically meant that we were discarding _any_ content from the blockchain event channels and just keeping data around in the persistent layer.

This PR aims to fix that, and on top adds unit tests and integration tests:

- It tries to cover the `chain` package and `pos` package introducing a simple test batch
- It adds an integration test to make sure the data emitted in the blockchain is correctly propagated between nodes

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to Masa! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR. 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

-->
