### PR TITLE
feat(api): Add configurable API server enablement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ install:
 run: build
 	@./bin/masa-node
 
-run-api: build
+run-api-enabled: build
 	@./bin/masa-node --api-enabled=true
 
 faucet: build

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ install:
 run: build
 	@./bin/masa-node
 
+run-api: build
+	@./bin/masa-node --api-enabled=true
+
 faucet: build
 	./bin/masa-node --faucet
 

--- a/pkg/config/app.go
+++ b/pkg/config/app.go
@@ -95,6 +95,8 @@ type AppConfig struct {
 	LLMCfUrl           string `mapstructure:"llmCfUrl"`
 
 	TelegramStop bg.StopFunc
+
+	APIEnabled bool `mapstructure:"apiEnabled"`
 }
 
 // GetInstance returns the singleton instance of AppConfig.
@@ -157,6 +159,8 @@ func (c *AppConfig) setDefaultConfig() {
 	viper.SetDefault(LogLevel, "info")
 	viper.SetDefault(LogFilePath, "masa_node.log")
 	viper.SetDefault(PrivKeyFile, filepath.Join(viper.GetString(MasaDir), "masa_oracle_key"))
+
+	viper.SetDefault("apiEnabled", false)
 }
 
 // setFileConfig loads configuration from a YAML file.
@@ -234,6 +238,7 @@ func (c *AppConfig) setCommandLineConfig() error {
 		return err
 	}
 	c.Bootnodes = strings.Split(bootnodes, ",")
+	pflag.BoolVar(&c.APIEnabled, "apiEnabled", viper.GetBool("apiEnabled"), "Enable API server")
 	return nil
 }
 

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -121,6 +121,7 @@ const (
 	LlmServer        = "LLM_SERVER"
 	LlmChatUrl       = "LLM_CHAT_URL"
 	LlmCfUrl         = "LLM_CF_URL"
+	APIEnabled       = "API_ENABLED"
 )
 
 // Function to call the Cloudflare API and parse the response


### PR DESCRIPTION
## Description

This PR a new feature that allows the API server to be conditionally enabled or disabled based on configuration. The changes include:

1. In cmd/masa-node/main.go:
   - Refactored signal handling into a separate function `handleSignals`
   - Added conditional logic to start the API server only if enabled
   - Improved logging to indicate API server status

2. In pkg/config/app.go:
   - Added `APIEnabled` field to the `AppConfig` struct
   - Set default value for `APIEnabled` to false in `setDefaultConfig`
   - Added command-line flag for `apiEnabled` in `setCommandLineConfig`

3. In pkg/config/constants.go:
   - Added `APIEnabled` constant for environment variable configuration

These changes provide more flexibility in node configuration, allowing users to run the node with or without the API server. This can be useful for security purposes or in scenarios where the API is not needed.

The API can now be enabled via:
- Environment variable: API_ENABLED=true
- Command-line flag: --api-enabled=true


By default, the API server will be **disabled** for enhanced security.