### PR TITLE
feat: worker selection tuning

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -9,7 +9,7 @@ type APIConfig struct {
 }
 
 var DefaultConfig = APIConfig{
-	WorkerResponseTimeout: 60 * time.Second,
+	WorkerResponseTimeout: 120 * time.Second,
 	// Set default values for other fields here
 }
 

--- a/pkg/workers/config.go
+++ b/pkg/workers/config.go
@@ -17,13 +17,13 @@ type WorkerConfig struct {
 }
 
 var DefaultConfig = WorkerConfig{
-	WorkerTimeout:         45 * time.Second,
-	WorkerResponseTimeout: 35 * time.Second,
+	WorkerTimeout:         55 * time.Second,
+	WorkerResponseTimeout: 45 * time.Second,
 	ConnectionTimeout:     500 * time.Millisecond,
 	MaxRetries:            1,
 	MaxSpawnAttempts:      1,
 	WorkerBufferSize:      100,
-	MaxRemoteWorkers:      25,
+	MaxRemoteWorkers:      10,
 }
 
 var workerConfig *WorkerConfig

--- a/pkg/workers/config.go
+++ b/pkg/workers/config.go
@@ -10,6 +10,7 @@ type WorkerConfig struct {
 	WorkerTimeout         time.Duration
 	WorkerResponseTimeout time.Duration
 	ConnectionTimeout     time.Duration
+	FindPeerTimeout       time.Duration
 	MaxRetries            int
 	MaxSpawnAttempts      int
 	WorkerBufferSize      int
@@ -19,7 +20,8 @@ type WorkerConfig struct {
 var DefaultConfig = WorkerConfig{
 	WorkerTimeout:         55 * time.Second,
 	WorkerResponseTimeout: 45 * time.Second,
-	ConnectionTimeout:     500 * time.Millisecond,
+	ConnectionTimeout:     75 * time.Millisecond,
+	FindPeerTimeout:       50 * time.Millisecond,
 	MaxRetries:            1,
 	MaxSpawnAttempts:      1,
 	WorkerBufferSize:      100,


### PR DESCRIPTION
**Description**

This pull request includes several changes to the configuration and handling of worker timeouts and peer discovery in the `pkg/api/config.go` and `pkg/workers` files. The most important changes are summarized below.

Configuration updates:

* [`pkg/api/config.go`](diffhunk://#diff-ae0afc2c35419636d0ebfb49cf74dda4544e535a112c222b17a6c301cbe4bfd1L12-R12): Increased `WorkerResponseTimeout` in `APIConfig` from 60 seconds to 120 seconds.
* [`pkg/workers/config.go`](diffhunk://#diff-5c1a5ce2f866633ea097d20d0c47a0225f715667d150053224a1b7a456d173b4R13-R28): Added a new `FindPeerTimeout` field to `WorkerConfig` and updated default values for several timeout-related fields.

Peer discovery improvements:

* [`pkg/workers/worker_manager.go`](diffhunk://#diff-1afd3fed6e81b9a9733b508a9a6b5bec482c1ec60ab20ffa30aec28a58890b09L131-R139): Added a timeout context for the `FindPeer` method to handle peer discovery within the specified `FindPeerTimeout`. Also added logging to differentiate between a timeout and other errors.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to Masa! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR. 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

-->
