### PR TITLE
chore(cleanup): Finish removing the AppConfig singleton and move Options processing to the config package

### DIFF
--- a/cmd/masa-node/main.go
+++ b/cmd/masa-node/main.go
@@ -30,7 +30,10 @@ func main() {
 		os.Exit(0)
 	}
 
-	cfg := config.GetInstance()
+	cfg, err := config.GetConfig()
+	if err != nil {
+		logrus.Fatalf("[-] %v", err)
+	}
 	cfg.LogConfig()
 	cfg.SetupLogging()
 

--- a/node/options.go
+++ b/node/options.go
@@ -32,7 +32,15 @@ type NodeOption struct {
 	Version              string
 	MasaDir              string
 	CachePath            string
-	KeyManager           *masacrypto.KeyManager
+
+	OracleProtocol       string
+	NodeDataSyncProtocol string
+	NodeGossipTopic      string
+	Rendezvous           string
+	WorkerProtocol       string
+	PageSize             int
+
+	KeyManager *masacrypto.KeyManager
 }
 
 type PubSubHandlers struct {
@@ -165,5 +173,41 @@ func WithCachePath(path string) Option {
 func WithKeyManager(km *masacrypto.KeyManager) Option {
 	return func(o *NodeOption) {
 		o.KeyManager = km
+	}
+}
+
+func WithOracleProtocol(s string) Option {
+	return func(o *NodeOption) {
+		o.OracleProtocol = s
+	}
+}
+
+func WithNodeDataSyncProtocol(s string) Option {
+	return func(o *NodeOption) {
+		o.NodeDataSyncProtocol = s
+	}
+}
+
+func WithNodeGossipTopic(s string) Option {
+	return func(o *NodeOption) {
+		o.NodeGossipTopic = s
+	}
+}
+
+func WithRendezvous(s string) Option {
+	return func(o *NodeOption) {
+		o.Rendezvous = s
+	}
+}
+
+func WithWorkerProtocol(s string) Option {
+	return func(o *NodeOption) {
+		o.WorkerProtocol = s
+	}
+}
+
+func WithPageSize(size int) Option {
+	return func(o *NodeOption) {
+		o.PageSize = size
 	}
 }

--- a/node/oracle_node_listener.go
+++ b/node/oracle_node_listener.go
@@ -14,7 +14,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/sirupsen/logrus"
 
-	"github.com/masa-finance/masa-oracle/pkg/config"
 	pubsub2 "github.com/masa-finance/masa-oracle/pkg/pubsub"
 )
 
@@ -42,7 +41,7 @@ func (node *OracleNode) ListenToNodeTracker() {
 				continue
 			}
 			// Publish the JSON data on the node.topic
-			err = node.PublishTopic(config.NodeGossipTopic, jsonData)
+			err = node.PublishTopic(node.Options.NodeGossipTopic, jsonData)
 			if err != nil {
 				logrus.Errorf("[-] Error publishing node data: %v", err)
 			}
@@ -88,10 +87,10 @@ type NodeDataPage struct {
 func (node *OracleNode) SendNodeDataPage(allNodeData []pubsub2.NodeData, stream network.Stream, pageNumber int) {
 	logrus.Debugf("[+] SendNodeDataPage --> %s: Page: %d", stream.Conn().RemotePeer(), pageNumber)
 	totalRecords := len(allNodeData)
-	totalPages := int(math.Ceil(float64(totalRecords) / config.PageSize))
+	totalPages := int(math.Ceil(float64(totalRecords) / float64(node.Options.PageSize)))
 
-	startIndex := pageNumber * config.PageSize
-	endIndex := startIndex + config.PageSize
+	startIndex := pageNumber * node.Options.PageSize
+	endIndex := startIndex + node.Options.PageSize
 	if endIndex > totalRecords {
 		endIndex = totalRecords
 	}
@@ -133,9 +132,9 @@ func (node *OracleNode) SendNodeData(peerID peer.ID) {
 		nodeData = node.NodeTracker.GetUpdatedNodes(sinceTime)
 	}
 	totalRecords := len(nodeData)
-	totalPages := int(math.Ceil(float64(totalRecords) / float64(config.PageSize)))
+	totalPages := int(math.Ceil(float64(totalRecords) / float64(node.Options.PageSize)))
 
-	stream, err := node.Host.NewStream(node.Context, peerID, node.protocolWithVersion(config.NodeDataSyncProtocol))
+	stream, err := node.Host.NewStream(node.Context, peerID, node.protocolWithVersion(node.Options.NodeDataSyncProtocol))
 	if err != nil {
 		// node.NodeTracker.RemoveNodeData(peerID.String())
 		return

--- a/node/protocol.go
+++ b/node/protocol.go
@@ -9,7 +9,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
-	"github.com/masa-finance/masa-oracle/pkg/config"
 )
 
 const (
@@ -50,7 +49,7 @@ func (node *OracleNode) subscribeToTopics() error {
 	}
 
 	// Subscribe to NodeGossipTopic to participate in the network's gossip protocol.
-	if err := node.SubscribeTopic(config.NodeGossipTopic, node.NodeTracker, false); err != nil {
+	if err := node.SubscribeTopic(node.Options.NodeGossipTopic, node.NodeTracker, false); err != nil {
 		return err
 	}
 

--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -1,0 +1,13 @@
+package config_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"github.com/masa-finance/masa-oracle/node"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("InitOptions", func() {
+	It("parses the AppConfig into NodeOptions", func() {
+		conf := AppConfig{
+			Version:         "1.0",
+			PortNbr:         42,
+			UDP:             true,
+			TCP:             true,
+			Bootnodes:       []string{"boot1", "boot2"},
+			Environment:     "test",
+			MasaDir:         "dir",
+			Validator:       true,
+			CachePath:       "cache",
+			TwitterScraper:  true,
+			DiscordScraper:  true,
+			TelegramScraper: true,
+			WebScraper:      true,
+		}
+
+		opts, _, _ := InitOptions(&conf)
+
+		actual := &node.NodeOption{}
+		actual.Apply(opts...)
+
+		// These have pointers to functions which we can't really compare.r
+		// Check that they aren't nil, then set them to nil for the rest of the test.
+		Expect(actual.Services).To(Not(BeNil()))
+		Expect(actual.PubSubHandles).To(Not(BeNil()))
+		Expect(actual.MasaProtocolHandlers).To(Not(BeNil()))
+		actual.Services = nil
+		actual.PubSubHandles = nil
+		actual.MasaProtocolHandlers = nil
+
+		expected := node.NodeOption{
+			IsStaked:             true,
+			UDP:                  conf.UDP,
+			TCP:                  conf.TCP,
+			IsValidator:          conf.Validator,
+			PortNbr:              conf.PortNbr,
+			IsTwitterScraper:     conf.TwitterScraper,
+			IsDiscordScraper:     conf.DiscordScraper,
+			IsTelegramScraper:    conf.TelegramScraper,
+			IsWebScraper:         conf.WebScraper,
+			Bootnodes:            conf.Bootnodes,
+			RandomIdentity:       false,
+			ProtocolHandlers:     nil,
+			Environment:          conf.Environment,
+			Version:              conf.Version,
+			MasaDir:              conf.MasaDir,
+			CachePath:            conf.CachePath,
+			OracleProtocol:       OracleProtocol,
+			NodeDataSyncProtocol: NodeDataSyncProtocol,
+			NodeGossipTopic:      NodeGossipTopic,
+			Rendezvous:           Rendezvous,
+			WorkerProtocol:       WorkerProtocol,
+			PageSize:             PageSize,
+
+			// Set these to the same values we set above
+			Services:             actual.Services,
+			PubSubHandles:        actual.PubSubHandles,
+			MasaProtocolHandlers: actual.MasaProtocolHandlers,
+		}
+
+		Expect(*actual).To(Equal(expected))
+	})
+})

--- a/pkg/network/kdht.go
+++ b/pkg/network/kdht.go
@@ -37,6 +37,7 @@ func EnableDHT(ctx context.Context, host host.Host, bootstrapNodes []multiaddr.M
 	options = append(options, dht.RoutingTableRefreshPeriod(time.Minute*5)) // Set refresh interval
 	options = append(options, dht.Mode(dht.ModeAutoServer))
 	options = append(options, dht.ProtocolPrefix(prefix))
+	// WTF: Why?
 	options = append(options, dht.NamespacedValidator("db", dbValidator{}))
 
 	kademliaDHT, err := dht.New(ctx, host, options...)

--- a/pkg/pubsub/manager.go
+++ b/pkg/pubsub/manager.go
@@ -83,7 +83,7 @@ func (sm *Manager) AddSubscription(topicName string, handler types.SubscriptionH
 		for {
 			msg, err := sub.Next(sm.ctx)
 			if err != nil {
-				logrus.Errorf("[-] Error reading from topic: %v", err)
+				logrus.Errorf("[-] AddSubscription: Error reading from topic: %v", err)
 				if errors.Is(err, context.Canceled) {
 					return
 				}
@@ -221,7 +221,7 @@ func (sm *Manager) Subscribe(topicName string, handler types.SubscriptionHandler
 		for {
 			msg, err := sub.Next(sm.ctx)
 			if err != nil {
-				logrus.Errorf("[-] Error reading from topic: %v", err)
+				logrus.Errorf("[-] Subscribe: Error reading from topic: %v", err)
 				if errors.Is(err, context.Canceled) {
 					return
 				}

--- a/pkg/pubsub/node_event_tracker.go
+++ b/pkg/pubsub/node_event_tracker.go
@@ -17,8 +17,10 @@ import (
 )
 
 type NodeEventTracker struct {
-	NodeDataChan  chan *NodeData
-	nodeData      *SafeMap
+	NodeDataChan chan *NodeData
+	// WTF: Do we really need this? Can't we store it in the libp2p PeerStore metadata?
+	nodeData *SafeMap
+	// WTF: Unused?
 	nodeDataFile  string
 	ConnectBuffer map[string]ConnectBufferEntry
 	nodeVersion   string
@@ -138,6 +140,7 @@ func (net *NodeEventTracker) Connected(n network.Network, c network.Conn) {
 
 	nodeData, exists := net.nodeData.Get(peerID)
 	if !exists {
+		// WTF: Shouldn't we add it? We don't yet have the NodeData but we can at least add it.
 		return
 	} else {
 		if nodeData.IsActive {
@@ -172,6 +175,7 @@ func (net *NodeEventTracker) Disconnected(n network.Network, c network.Conn) {
 	nodeData, exists := net.nodeData.Get(peerID)
 	if !exists {
 		// this should never happen
+		// WTF: Since we're never adding it on `Connected`....
 		logrus.Debugf("Node data does not exist for disconnected node: %s", peerID)
 		return
 	}

--- a/pkg/tests/integration/tracker_test.go
+++ b/pkg/tests/integration/tracker_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	. "github.com/masa-finance/masa-oracle/node"
+	"github.com/masa-finance/masa-oracle/pkg/config"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -19,8 +20,10 @@ var _ = Describe("Oracle integration tests", func() {
 
 			n, err := NewOracleNode(
 				ctx,
-				EnableStaked,
-				EnableRandomIdentity,
+				config.WithConstantOptions(
+					EnableStaked,
+					EnableRandomIdentity,
+				)...,
 			)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -36,10 +39,13 @@ var _ = Describe("Oracle integration tests", func() {
 			}
 
 			By(fmt.Sprintf("Generating second node with bootnodes %+v", bootNodes))
-			n2, err := NewOracleNode(ctx,
-				EnableStaked,
-				WithBootNodes(bootNodes...),
-				EnableRandomIdentity,
+			n2, err := NewOracleNode(
+				ctx,
+				config.WithConstantOptions(
+					EnableStaked,
+					WithBootNodes(bootNodes...),
+					EnableRandomIdentity,
+				)...,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(n.Host.ID()).ToNot(Equal(n2.Host.ID()))

--- a/pkg/tests/node_data/node_data_tracker_test.go
+++ b/pkg/tests/node_data/node_data_tracker_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/masa-finance/masa-oracle/node"
+	"github.com/masa-finance/masa-oracle/pkg/config"
 	"github.com/masa-finance/masa-oracle/pkg/pubsub"
 )
 
@@ -16,8 +17,10 @@ var _ = Describe("NodeDataTracker", func() {
 		It("should correctly update NodeData Twitter fields", func() {
 			testNode, err := NewOracleNode(
 				context.Background(),
-				EnableStaked,
-				EnableRandomIdentity,
+				config.WithConstantOptions(
+					EnableStaked,
+					EnableRandomIdentity,
+				)...,
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/workers/handlers/web.go
+++ b/pkg/workers/handlers/web.go
@@ -11,7 +11,6 @@ import (
 
 // WebHandler - All the web handlers implement the WorkHandler interface.
 type WebHandler struct{}
-type WebSentimentHandler struct{}
 
 func (h *WebHandler) HandleWork(data []byte) data_types.WorkResponse {
 	logrus.Infof("[+] WebHandler %s", data)

--- a/pkg/workers/types/work_types.go
+++ b/pkg/workers/types/work_types.go
@@ -12,7 +12,6 @@ const (
 	Discord                 WorkerType = "discord"
 	DiscordProfile          WorkerType = "discord-profile"
 	DiscordChannelMessages  WorkerType = "discord-channel-messages"
-	TelegramSentiment       WorkerType = "telegram-sentiment"
 	TelegramChannelMessages WorkerType = "telegram-channel-messages"
 	DiscordGuildChannels    WorkerType = "discord-guild-channels"
 	DiscordUserGuilds       WorkerType = "discord-user-guilds"
@@ -35,7 +34,7 @@ func WorkerTypeToCategory(wt WorkerType) pubsub.WorkerCategory {
 	case Discord, DiscordProfile, DiscordChannelMessages, DiscordGuildChannels, DiscordUserGuilds:
 		logrus.Info("WorkerType is related to Discord")
 		return pubsub.CategoryDiscord
-	case TelegramSentiment, TelegramChannelMessages:
+	case TelegramChannelMessages:
 		logrus.Info("WorkerType is related to Telegram")
 		return pubsub.CategoryTelegram
 	case Twitter, TwitterFollowers, TwitterProfile:
@@ -57,7 +56,7 @@ func WorkerTypeToDataSource(wt WorkerType) string {
 	case Discord, DiscordProfile, DiscordChannelMessages, DiscordGuildChannels, DiscordUserGuilds:
 		logrus.Info("WorkerType is related to Discord")
 		return DataSourceDiscord
-	case TelegramSentiment, TelegramChannelMessages:
+	case TelegramChannelMessages:
 		logrus.Info("WorkerType is related to Telegram")
 		return DataSourceTelegram
 	case Twitter, TwitterFollowers, TwitterProfile:

--- a/pkg/workers/worker_manager.go
+++ b/pkg/workers/worker_manager.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/masa-finance/masa-oracle/node"
-	"github.com/masa-finance/masa-oracle/pkg/config"
 	"github.com/masa-finance/masa-oracle/pkg/event"
 	"github.com/masa-finance/masa-oracle/pkg/pubsub"
 	"github.com/masa-finance/masa-oracle/pkg/workers/handlers"
@@ -214,7 +213,7 @@ func (whm *WorkHandlerManager) sendWorkToWorker(node *node.OracleNode, worker da
 	} else {
 		//whm.eventTracker.TrackRemoteWorkerConnection(worker.AddrInfo.ID.String())
 		logrus.Debugf("[+] Connection established with node: %s", worker.AddrInfo.ID.String())
-		stream, err := node.ProtocolStream(ctxWithTimeout, worker.AddrInfo.ID, config.WorkerProtocol)
+		stream, err := node.ProtocolStream(ctxWithTimeout, worker.AddrInfo.ID, node.Options.WorkerProtocol)
 		if err != nil {
 			response.Error = fmt.Sprintf("error opening stream: %v", err)
 			whm.eventTracker.TrackWorkerFailure(workRequest.WorkType, response.Error, worker.AddrInfo.ID.String())


### PR DESCRIPTION
**Description**

After #623, #625 and #626, this is the final cleanup step. Our code is now singleton-free, and the circular dependencies that prevented us from moving Options processing to the `config` package are no more.

**Notes for Reviewers**

Die, singletons, die!!!!!

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to Masa! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR. 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

-->
