### PR TITLE
chore(cleanup): Get rid of priority multiaddr, publish all of a node's multiaddresses

### DIFF
--- a/cmd/masa-node/main.go
+++ b/cmd/masa-node/main.go
@@ -6,8 +6,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/multiformats/go-multiaddr"
-
 	"github.com/masa-finance/masa-oracle/internal/versioning"
 
 	"github.com/sirupsen/logrus"
@@ -114,13 +112,12 @@ func main() {
 	}
 
 	// Get the multiaddress and IP address of the node
-	multiAddr := masaNode.GetMultiAddrs()                      // Get the multiaddress
-	ipAddr, err := multiAddr.ValueForProtocol(multiaddr.P_IP4) // Get the IP address
+	multiAddrs, err := masaNode.GetP2PMultiAddrs()
 	if err != nil {
-		logrus.Errorf("[-] Error while getting node IP address from %v: %v", multiAddr, err)
+		logrus.Errorf("[-] Error while getting node multiaddrs: %v", err)
+	} else {
+		config.DisplayWelcomeMessage(multiAddrs, cfg.KeyManager.EthAddress, isStaked, cfg.Validator, cfg.TwitterScraper, cfg.TelegramScraper, cfg.DiscordScraper, cfg.WebScraper, versioning.ApplicationVersion, versioning.ProtocolVersion)
 	}
-	// Display the welcome message with the multiaddress and IP address
-	config.DisplayWelcomeMessage(multiAddr.String(), ipAddr, cfg.KeyManager.EthAddress, isStaked, cfg.Validator, cfg.TwitterScraper, cfg.TelegramScraper, cfg.DiscordScraper, cfg.WebScraper, versioning.ApplicationVersion, versioning.ProtocolVersion)
 
 	<-ctx.Done()
 }

--- a/pkg/config/welcome.go
+++ b/pkg/config/welcome.go
@@ -2,13 +2,29 @@ package config
 
 import (
 	"fmt"
+
+	"github.com/multiformats/go-multiaddr"
+	"github.com/sirupsen/logrus"
 )
 
-func DisplayWelcomeMessage(multiAddr, ipAddr, publicKeyHex string, isStaked bool, isValidator bool, isTwitterScraper bool, isTelegramScraper bool, isDiscordScraper bool, isWebScraper bool, version, protocolVersion string) {
+func DisplayWelcomeMessage(multiAddrs []multiaddr.Multiaddr, publicKeyHex string, isStaked bool, isValidator bool, isTwitterScraper bool, isTelegramScraper bool, isDiscordScraper bool, isWebScraper bool, version, protocolVersion string) {
 	// ANSI escape code for yellow text
 	yellow := "\033[33m"
 	blue := "\033[34m"
 	reset := "\033[0m"
+
+	var maddrs, ips string
+
+	for _, ma := range multiAddrs {
+		ip, err := ma.ValueForProtocol(multiaddr.P_IP4) // Get the IP address
+		if err != nil {
+			logrus.Errorf("[-] Error while parsing getting IP address for %v: %v", ma, err)
+			continue
+		}
+
+		maddrs = fmt.Sprintf("%s %s", maddrs, ma)
+		ips = fmt.Sprintf("%s %s", ips, ip)
+	}
 
 	fmt.Println("")
 	borderLine := "#######################################"
@@ -25,8 +41,8 @@ func DisplayWelcomeMessage(multiAddr, ipAddr, publicKeyHex string, isStaked bool
 
 	fmt.Printf(blue+"%-20s %s\n"+reset, "Application Version:", yellow+version)
 	fmt.Printf(blue+"%-20s %s\n"+reset, "Protocol Version:", yellow+protocolVersion)
-	fmt.Printf(blue+"%-20s %s\n"+reset, "Multiaddress:", multiAddr)
-	fmt.Printf(blue+"%-20s %s\n"+reset, "IP Address:", ipAddr)
+	fmt.Printf(blue+"%-20s %s\n"+reset, "Multiaddresses:", maddrs)
+	fmt.Printf(blue+"%-20s %s\n"+reset, "IP Addresses:", ips)
 	fmt.Printf(blue+"%-20s %s\n"+reset, "Public Key:", publicKeyHex)
 	fmt.Printf(blue+"%-20s %t\n"+reset, "Is Staked:", isStaked)
 	fmt.Printf(blue+"%-20s %t\n"+reset, "Is Validator:", isValidator)

--- a/pkg/network/address.go
+++ b/pkg/network/address.go
@@ -1,10 +1,6 @@
 package network
 
 import (
-	"fmt"
-	"io"
-	"net"
-	"net/http"
 	"strings"
 
 	"github.com/libp2p/go-libp2p/core/host"
@@ -12,9 +8,6 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/sirupsen/logrus"
 )
-
-// The URL of the GCP metadata server for the external IP
-const externalIPURL = "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip"
 
 // GetMultiAddressesForHost returns the multiaddresses for the host
 func GetMultiAddressesForHost(host host.Host) ([]multiaddr.Multiaddr, error) {
@@ -36,170 +29,6 @@ func GetMultiAddressesForHost(host host.Host) ([]multiaddr.Multiaddr, error) {
 		}
 	}
 	return addresses, nil
-}
-
-// getPublicMultiAddress returns the best public IP address (for some definition of "best")
-// TODO: This is not guaranteed to work, and should not be necessary since we're using AutoNAT
-func getPublicMultiAddress(addrs []multiaddr.Multiaddr) multiaddr.Multiaddr {
-	ipBytes, err := Get("https://api.ipify.org?format=text", nil)
-	externalIP := net.ParseIP(string(ipBytes))
-	if err != nil {
-		logrus.Warnf("[-] Failed to get public IP: %v", err)
-		return nil
-	}
-	if externalIP == nil || externalIP.IsPrivate() {
-		return nil
-	}
-
-	var addrToCopy multiaddr.Multiaddr
-	if len(addrs) > 0 {
-		addrToCopy = addrs[0]
-	}
-	publicMultiaddr, err := replaceIPComponent(addrToCopy, externalIP.String())
-	if err != nil {
-		logrus.Warnf("[-] Failed to create multiaddr with public IP: %v", err)
-		return nil
-	}
-	return publicMultiaddr
-}
-
-// GetPriorityAddress returns the best public or private IP address
-// TODO: rm?
-func GetPriorityAddress(addrs []multiaddr.Multiaddr) multiaddr.Multiaddr {
-	var bestPrivateAddr multiaddr.Multiaddr
-	bestPublicAddr := getPublicMultiAddress(addrs)
-
-	for _, addr := range addrs {
-		ipComponent, err := addr.ValueForProtocol(multiaddr.P_IP4)
-		if err != nil {
-			ipComponent, err = addr.ValueForProtocol(multiaddr.P_IP6)
-			if err != nil {
-				continue // Not an IP address
-			}
-		}
-		ip := net.ParseIP(ipComponent)
-		if ip == nil || ip.IsLoopback() {
-			continue // Skip invalid or loopback addresses
-		}
-		if ip.IsPrivate() {
-			// If it's the first private address found or if it's preferred over the current best, keep it
-			if bestPrivateAddr == nil || isPreferredAddress(addr) {
-				bestPrivateAddr = addr
-			}
-		} else {
-			// If it's the first public address found or if it's preferred over the current best, keep it
-			if bestPublicAddr == nil || isPreferredAddress(addr) {
-				bestPublicAddr = addr
-			}
-		}
-	}
-	var baseAddr multiaddr.Multiaddr
-	// Prefer public addresses over private ones
-	if bestPublicAddr != nil {
-		baseAddr = bestPublicAddr
-	} else if bestPrivateAddr != nil {
-		baseAddr = bestPrivateAddr
-	} else {
-		logrus.Warn("No address matches the priority criteria, returning the first entry")
-		baseAddr = addrs[0]
-	}
-	logrus.Infof("Best public address: %s", bestPublicAddr)
-	logrus.Debugf("Best private address: %s", bestPrivateAddr)
-	logrus.Debugf("Base address: %s", baseAddr)
-	gcpAddr := replaceGCPAddress(baseAddr)
-	if gcpAddr != nil {
-		baseAddr = gcpAddr
-	}
-	return baseAddr
-}
-
-func replaceGCPAddress(addr multiaddr.Multiaddr) multiaddr.Multiaddr {
-	// After finding the best address, try to get the GCP external IP
-	var err error
-	var bestAddr multiaddr.Multiaddr
-	gotExternalIP, externalIP := getGCPExternalIP()
-	if gotExternalIP && externalIP != "" {
-		bestAddr, err = replaceIPComponent(addr, externalIP)
-		if err != nil {
-			logrus.Warnf("Failed to replace IP component: %s", err)
-			return nil
-		}
-	}
-	logrus.Debug("Got external IP: ", gotExternalIP)
-	logrus.Debug("Address after replacing IP component: ", bestAddr)
-	return bestAddr
-}
-
-func replaceIPComponent(maddr multiaddr.Multiaddr, newIP string) (multiaddr.Multiaddr, error) {
-	var components []multiaddr.Multiaddr
-	for _, component := range multiaddr.Split(maddr) {
-		if component.Protocols()[0].Code == multiaddr.P_IP4 || component.Protocols()[0].Code == multiaddr.P_IP6 {
-			// Create a new IP component
-			newIPComponent, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s", newIP))
-			if err != nil {
-				return nil, err
-			}
-			components = append(components, newIPComponent)
-		} else {
-			components = append(components, component)
-		}
-	}
-	return multiaddr.Join(components...), nil
-}
-
-func getGCPExternalIP() (bool, string) {
-
-	// Create a new HTTP client with a specific timeout
-	client := &http.Client{}
-
-	// Make a request to the metadata server
-	req, err := http.NewRequest("GET", externalIPURL, nil)
-	if err != nil {
-		return false, ""
-	}
-
-	// GCP metadata server requires this specific header
-	req.Header.Add("Metadata-Flavor", "Google")
-
-	// Perform the request
-	resp, err := client.Do(req)
-	if err != nil {
-		return false, ""
-	}
-	defer func(Body io.ReadCloser) {
-		err := Body.Close()
-		if err != nil {
-			logrus.Error(err)
-		}
-	}(resp.Body)
-
-	// Check if the metadata server returns a successful status code
-	if resp.StatusCode != http.StatusOK {
-		logrus.Debug("Metadata server response status: ", resp.StatusCode)
-		return false, ""
-	}
-	//Read the external IP from the response
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return true, ""
-	}
-	// Check that the response is a valid IP address
-	if net.ParseIP(string(body)) == nil {
-		return false, ""
-	}
-	logrus.Debug("External IP from metadata server: ", string(body))
-	return true, string(body)
-}
-
-// isPreferredAddress checks if the multiaddress contains the UDP protocol
-func isPreferredAddress(addr multiaddr.Multiaddr) bool {
-	// Check if the multiaddress contains the UDP protocol
-	for _, p := range addr.Protocols() {
-		if p.Code == multiaddr.P_UDP {
-			return true
-		}
-	}
-	return false
 }
 
 // GetBootNodesMultiAddress returns the multiaddresses for the bootstrap nodes

--- a/pkg/network/discover.go
+++ b/pkg/network/discover.go
@@ -117,13 +117,11 @@ func Discover(ctx context.Context, bootNodes []string, host host.Host, dht *dht.
 							logrus.Warningf("[-] Failed to connect to peer %s, will retry...", availPeer.ID.String())
 							continue
 						} else {
-							logrus.Infof("[+] Connected to peer %s", availPeer.ID.String())
-						}
-					} else {
-						for _, bn := range bootNodes {
-							if len(bn) > 0 {
-								logrus.Info("[-] Not connected to any bootnode. Attempting to reconnect...")
-								reconnectToBootnodes(ctx, host, bootNodes)
+							for _, bn := range bootNodes {
+								if len(bn) > 0 {
+									logrus.Info("[-] Not connected to any bootnode. Attempting to reconnect...")
+									reconnectToBootnodes(ctx, host, bootNodes)
+								}
 							}
 						}
 					}

--- a/pkg/network/kdht.go
+++ b/pkg/network/kdht.go
@@ -37,7 +37,6 @@ func EnableDHT(ctx context.Context, host host.Host, bootstrapNodes []multiaddr.M
 	options = append(options, dht.RoutingTableRefreshPeriod(time.Minute*5)) // Set refresh interval
 	options = append(options, dht.Mode(dht.ModeAutoServer))
 	options = append(options, dht.ProtocolPrefix(prefix))
-	// WTF: Why?
 	options = append(options, dht.NamespacedValidator("db", dbValidator{}))
 
 	kademliaDHT, err := dht.New(ctx, host, options...)
@@ -87,7 +86,7 @@ func EnableDHT(ctx context.Context, host host.Host, bootstrapNodes []multiaddr.M
 		} else if !added {
 			logrus.Warningf("[-] Bootstrap peer %s was not added to DHT", peerInfo.ID)
 		} else {
-			logrus.Infof("[+] Successfully added bootstrap peer %s to DHT", peerInfo.ID)
+			logrus.Infof("[+] Successfully added bootstrap peer %s to DHT: %v", peerInfo.ID, peerInfo)
 		}
 
 		wg.Add(1)

--- a/pkg/pubsub/node_data.go
+++ b/pkg/pubsub/node_data.go
@@ -74,14 +74,19 @@ type NodeData struct {
 
 // NewNodeData creates a new NodeData struct initialized with the given
 // parameters. It is used to represent data about a node in the network.
-func NewNodeData(addr multiaddr.Multiaddr, peerId peer.ID, publicKey string, activity int) *NodeData {
+func NewNodeData(addrs []multiaddr.Multiaddr, peerId peer.ID, publicKey string, activity int) *NodeData {
 	multiaddrs := make([]JSONMultiaddr, 0)
-	multiaddrs = append(multiaddrs, JSONMultiaddr{addr})
+	var mas string
+
+	for _, ma := range addrs {
+		multiaddrs = append(multiaddrs, JSONMultiaddr{ma})
+		mas = fmt.Sprintf("%s %s", mas, ma.String())
+	}
 
 	return &NodeData{
 		PeerId:            peerId,
 		Multiaddrs:        multiaddrs,
-		MultiaddrsString:  addr.String(),
+		MultiaddrsString:  mas,
 		LastUpdatedUnix:   time.Now().Unix(),
 		CurrentUptime:     0,
 		AccumulatedUptime: 0,


### PR DESCRIPTION
**Description**

<!-- This PR fixes # --> While doing local testing I found a problem: a node was only publishing its external IP address (found by connecting to an external service). The issue was that, when running 2 nodes in my LAN for testing, they were trying to connect via the external IP, which my router does not allow.

This is completely unnecessary in libp2p (the "priority multiaddr" was there because of some long-removed legacy code). Libp2p will publish all the multiaddrs that it knows about, and when a node connects to another node it will also add to the DHT the address as observed by the other node. So let's let libp2p do its thing and forget about this "priority multiaddr" shenanigans.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to Masa! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR. 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

-->
