### PR TITLE
feat: tweet by id support

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -74,6 +74,43 @@ const docTemplate = `{
 		  ]
 		}
 	  },
+	  "/data/twitter/tweets/{id}": {
+		"post": {
+		  "description": "Retrieves a specific tweet by its ID.",
+		  "consumes": ["application/json"],
+		  "produces": ["application/json"],
+		  "tags": ["Twitter"],
+		  "summary": "Search Tweet by ID",
+		  "parameters": [
+			{
+			  "type": "string",
+			  "description": "Tweet ID",
+			  "name": "id",
+			  "in": "path",
+			  "required": true
+			}
+		  ],
+		  "responses": {
+			"200": {
+			  "description": "Successfully retrieved tweet",
+			  "schema": {
+				"$ref": "#/definitions/Tweet"
+			  }
+			},
+			"400": {
+			  "description": "Invalid tweet ID or error fetching tweet",
+			  "schema": {
+				"$ref": "#/definitions/ErrorResponse"
+			  }
+			}
+		  },
+		  "security": [
+			{
+			  "Bearer": []
+			}
+		  ]
+		}
+	  },
 	  "/data/twitter/followers/{username}": {
 		"get": {
 		  "description": "Retrieves followers from a specific Twitter profile.",

--- a/pkg/api/handlers_data.go
+++ b/pkg/api/handlers_data.go
@@ -185,24 +185,23 @@ func (api *API) SearchTweetsProfile() gin.HandlerFunc {
 }
 
 // SearchTweetById returns a gin.HandlerFunc that processes a request to search for a tweet by its ID.
-// It expects a JSON body with a field "id" (string), representing the tweet ID to search for.
-// The handler validates the request body, ensuring the ID is not empty.
+// It expects the tweet ID to be provided as a URL parameter.
+// The handler validates the request, ensuring the ID is not empty.
 // If the request is valid, it attempts to scrape the tweet using the specified ID.
 // On success, it returns the scraped tweet in a JSON response. On failure, it returns an appropriate error message and HTTP status code.
 func (api *API) SearchTweetById() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var reqBody struct {
-			ID string `json:"id"`
-		}
+		tweetID := c.Param("id")
 
-		if err := c.ShouldBindJSON(&reqBody); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
-			return
-		}
-
-		if reqBody.ID == "" {
+		if tweetID == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "ID must be provided and valid"})
 			return
+		}
+
+		reqBody := struct {
+			ID string `json:"id"`
+		}{
+			ID: tweetID,
 		}
 
 		bodyBytes, err := json.Marshal(reqBody)

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -217,7 +217,7 @@ func SetupRoutes(node *node.OracleNode, workerManager *workers.WorkHandlerManage
 		// @Param   id   path    string  true  "Tweet ID"
 		// @Success 200 {object} Tweet "Successfully retrieved tweet"
 		// @Failure 400 {object} ErrorResponse "Invalid tweet ID or error fetching tweet"
-		// @Router /data/twitter/tweets/id [post]
+		// @Router /data/twitter/tweets/{id} [post]
 		v1.POST("/data/twitter/tweets/:id", API.SearchTweetById())
 
 		// @Summary Search Discord Profile

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -209,6 +209,9 @@ func SetupRoutes(node *node.OracleNode, workerManager *workers.WorkHandlerManage
 		// @Example safeSearch {"query": "Masa filter:safe", "count": 10}
 		v1.POST("/data/twitter/tweets/recent", API.SearchTweetsRecent())
 
+		// TODO write swagger docs code for this
+		v1.POST("/data/twitter/tweets/id", API.SearchTweetById())
+
 		// @Summary Search Discord Profile
 		// @Description Retrieves a Discord user profile by user ID.
 		// @Tags Discord

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -209,8 +209,16 @@ func SetupRoutes(node *node.OracleNode, workerManager *workers.WorkHandlerManage
 		// @Example safeSearch {"query": "Masa filter:safe", "count": 10}
 		v1.POST("/data/twitter/tweets/recent", API.SearchTweetsRecent())
 
-		// TODO write swagger docs code for this
-		v1.POST("/data/twitter/tweets/id", API.SearchTweetById())
+		// @Summary Search Tweet by ID
+		// @Description Retrieves a specific tweet by its ID.
+		// @Tags Twitter
+		// @Accept  json
+		// @Produce  json
+		// @Param   id   path    string  true  "Tweet ID"
+		// @Success 200 {object} Tweet "Successfully retrieved tweet"
+		// @Failure 400 {object} ErrorResponse "Invalid tweet ID or error fetching tweet"
+		// @Router /data/twitter/tweets/id [post]
+		v1.POST("/data/twitter/tweets/:id", API.SearchTweetById())
 
 		// @Summary Search Discord Profile
 		// @Description Retrieves a Discord user profile by user ID.

--- a/pkg/scrapers/twitter/tweets.go
+++ b/pkg/scrapers/twitter/tweets.go
@@ -11,6 +11,22 @@ type TweetResult struct {
 	Error error
 }
 
+func ScrapeTweetByID(id string) (*twitterscraper.Tweet, error) {
+	scraper, account, err := getAuthenticatedScraper()
+	if err != nil {
+		return nil, err
+	}
+
+	tweet, err := scraper.GetTweet(id)
+	if err != nil {
+		if handleRateLimit(err, account) {
+			return nil, err
+		}
+		return nil, err
+	}
+	return tweet, nil
+}
+
 func ScrapeTweetsByQuery(query string, count int) ([]*TweetResult, error) {
 	scraper, account, err := getAuthenticatedScraper()
 	if err != nil {

--- a/pkg/workers/handlers/twitter.go
+++ b/pkg/workers/handlers/twitter.go
@@ -12,6 +12,28 @@ import (
 type TwitterQueryHandler struct{}
 type TwitterFollowersHandler struct{}
 type TwitterProfileHandler struct{}
+type TwitterTweetHandler struct{}
+
+func (h *TwitterTweetHandler) HandleWork(data []byte) data_types.WorkResponse {
+	logrus.Infof("[+] TwitterTweetHandler input: %s", data)
+	dataMap, err := JsonBytesToMap(data)
+	if err != nil {
+		logrus.Errorf("[+] TwitterTweetHandler error parsing data: %v", err)
+		return data_types.WorkResponse{Error: fmt.Sprintf("unable to parse tweet data: %v", err)}
+	}
+	tweetID := dataMap["id"].(string)
+
+	logrus.Infof("[+] Fetching tweet with ID: %s", tweetID)
+
+	resp, err := twitter.ScrapeTweetByID(tweetID)
+	if err != nil {
+		logrus.Errorf("[+] TwitterTweetHandler error fetching tweet: %v", err)
+		return data_types.WorkResponse{Error: err.Error()}
+	}
+
+	logrus.Infof("[+] TwitterTweetHandler Work response for %s: tweet returned", data_types.TwitterTweet)
+	return data_types.WorkResponse{Data: resp, RecordCount: 1}
+}
 
 func (h *TwitterQueryHandler) HandleWork(data []byte) data_types.WorkResponse {
 	logrus.Infof("[+] TwitterQueryHandler input: %s", data)

--- a/pkg/workers/types/work_types.go
+++ b/pkg/workers/types/work_types.go
@@ -21,6 +21,7 @@ const (
 	Twitter                 WorkerType = "twitter"
 	TwitterFollowers        WorkerType = "twitter-followers"
 	TwitterProfile          WorkerType = "twitter-profile"
+	TwitterTweet            WorkerType = "twitter-tweet"
 	Web                     WorkerType = "web"
 	WebSentiment            WorkerType = "web-sentiment"
 	Test                    WorkerType = "test"
@@ -41,7 +42,7 @@ func WorkerTypeToCategory(wt WorkerType) pubsub.WorkerCategory {
 	case TelegramSentiment, TelegramChannelMessages:
 		logrus.Info("WorkerType is related to Telegram")
 		return pubsub.CategoryTelegram
-	case Twitter, TwitterFollowers, TwitterProfile:
+	case Twitter, TwitterFollowers, TwitterProfile, TwitterTweet:
 		logrus.Info("WorkerType is related to Twitter")
 		return pubsub.CategoryTwitter
 	case Web, WebSentiment:
@@ -63,7 +64,7 @@ func WorkerTypeToDataSource(wt WorkerType) string {
 	case TelegramSentiment, TelegramChannelMessages:
 		logrus.Info("WorkerType is related to Telegram")
 		return DataSourceTelegram
-	case Twitter, TwitterFollowers, TwitterProfile:
+	case Twitter, TwitterFollowers, TwitterProfile, TwitterTweet:
 		logrus.Info("WorkerType is related to Twitter")
 		return DataSourceTwitter
 	case Web, WebSentiment:

--- a/pkg/workers/worker_manager.go
+++ b/pkg/workers/worker_manager.go
@@ -36,6 +36,7 @@ func NewWorkHandlerManager(opts ...WorkerOptionFunc) *WorkHandlerManager {
 		whm.addWorkHandler(data_types.Twitter, &handlers.TwitterQueryHandler{})
 		whm.addWorkHandler(data_types.TwitterFollowers, &handlers.TwitterFollowersHandler{})
 		whm.addWorkHandler(data_types.TwitterProfile, &handlers.TwitterProfileHandler{})
+		whm.addWorkHandler(data_types.TwitterTweet, &handlers.TwitterTweetHandler{})
 	}
 
 	if options.isWebScraperWorker {


### PR DESCRIPTION
**Description**

This PR adds support for getting a tweet by id.  It exposes `v1.POST("/data/twitter/tweets/:id", API.SearchTweetById())` which leverages the `scraper.GetTweet(id)` method of `github.com/imperatrona/twitter-scraper`.

The necessary data_types are also added, adding `TwitterTweet            WorkerType = "twitter-tweet"`

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to Masa! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR. 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

-->
